### PR TITLE
Enable encryption by passing S3 KMS key ARN

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -295,6 +295,9 @@ resource "aws_kinesis_firehose_delivery_stream" "waf" {
   destination = "extended_s3"
 
   extended_s3_configuration {
+    # Ensure encrytped delivery stream - https://www.cloudconformity.com/knowledge-base/aws/Firehose/delivery-stream-encrypted.html
+    kms_key_arn = "${var.s3_kms_key_arn}"
+
     role_arn   = "${aws_iam_role.firehose.arn}"
     bucket_arn = "${aws_s3_bucket.webacl_traffic_information.arn}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,11 @@ variable "s3_logging_bucket" {
   description = "The name of the target S3 Bucket which store Access Logs for WebACL Bucket created by this module"
 }
 
+variable "s3_kms_key_arn" {
+  type        = "string"
+  description = "KMS key ARN for S3 encryption"
+}
+
 variable "firehose_buffer_size" {
   type        = "string"
   description = "Buffer incoming data to the specified size, in MBs, before delivering it to the destination. Valid value is between 64-128. Recommended is 128, specifying a smaller buffer size can result in the delivery of very small S3 objects, which are less efficient to query."


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #17 

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-waf-webacl-supporting-resources/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* User needs to provide `s3_kms_key_arn` for S3 encrytion.

BUG FIXES:

* Enable Firehose Delivery Stream Encryption for S3
```
