### PR TITLE
add bpa for s3 bucket with traffic logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,15 @@ resource "aws_s3_bucket" "webacl_traffic_information" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.webacl_traffic_information.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 # AWS Glue Catalog Database. This resource is needed by Amazon Kinesis Firehose as data format conversion configuration, for transforming from JSON to Parquet.
 resource "aws_glue_catalog_database" "database" {
   name        = "${lower(var.service_name)}_webacl_${random_id.this.hex}"


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

Fixed Block Public Access for S3 bucket that stores Traffic logs
Fixes #22 

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-waf-webacl-supporting-resources/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

ENHANCEMENTS:

* feature: Adds Block Public Access to traffic logs
```
### Potential plans
```
  # module.webacl_supporting_resources.aws_s3_bucket_public_access_block.this will be created
  + resource "aws_s3_bucket_public_access_block" "this" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = "<Some bucket name>"
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }
```
