### PR TITLE
Add transition lifecycle for bucket logging

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  lifecycle_rules = [
+    {
+      id      = "webacl-logs-lifecycle"
+      enabled = true
+      expiration = [
+        {
+          days = var.webacl_traffic_log_expiration
+        },
+      ]
+    }
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,28 @@ resource "aws_s3_bucket" "webacl_traffic_information" {
     target_prefix = "${lower(var.service_name)}-webacl-${data.aws_region.this.name}-${data.aws_caller_identity.this.account_id}-${random_id.this.hex}/"
   }
 
+  dynamic "lifecycle_rule" {
+    for_each = concat(local.lifecycle_rules, var.webacl_traffic_log_additional_lifecycle)
+    content {
+      id      = lookup(lifecycle_rule.value, "id", null)
+      enabled = lookup(lifecycle_rule.value, "enabled", false)
+      dynamic "transition" {
+        for_each = lookup(lifecycle_rule.value, "transition", [])
+        content {
+          days          = lookup(transition.value, "days", null)
+          storage_class = lookup(transition.value, "storage_class", null)
+        }
+      }
+
+      dynamic "expiration" {
+        for_each = lookup(lifecycle_rule.value, "expiration", [])
+        content {
+          days = lookup(expiration.value, "days", null)
+        }
+      }
+    }
+  }
+
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {

--- a/variables.tf
+++ b/variables.tf
@@ -41,3 +41,25 @@ variable "firehose_buffer_interval" {
   default     = "900"
 }
 
+variable "webacl_traffic_log_additional_lifecycle" {
+  type = list(object({
+    id      = string,
+    enabled = bool,
+    prefix  = string,
+    transition = list(object({
+      days          = string
+      storage_class = string
+    }))
+    expiration = list(object({
+      days = string
+    }))
+  }))
+  description = "Extra lifecycle rules"
+  default     = []
+}
+
+variable "webacl_traffic_log_expiration" {
+  type        = string
+  description = "Web acl expiration"
+  default     = 365
+}


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
### BACKGROUND & MOTIVATION:

The existing bucket is quite large that we initiate to move from standard s3 storage to glacier. This PR is supposed to achieve that goal 


```release-note

ENHANCEMENTS:

* feature: Add  transition lifecycle for bucket logging

```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```
### How i tested this
- [x] terraform validate
<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
